### PR TITLE
More changes to clustering

### DIFF
--- a/clustering/cluster_test.go
+++ b/clustering/cluster_test.go
@@ -63,11 +63,11 @@ func TestNewCluster(t *testing.T) {
 	}
 }
 
-func TestClusterCombine(t *testing.T) {
+func TestCombineClusters(t *testing.T) {
 	c1 := NewCluster(&event{Location: geo.NewPoint(1, 0)})
 	c2 := NewCluster(&event{Location: geo.NewPoint(2, 1)})
 
-	c1.Combine(c2)
+	c1 = CombineClusters(c1, c2)
 	if !c1.Centroid.Equals(geo.NewPoint(1.5, 0.5)) {
 		t.Errorf("centroid not adjusted correctly, got %v", c1.Centroid)
 	}
@@ -77,8 +77,7 @@ func TestClusterCombine(t *testing.T) {
 	}
 
 	c3 := NewCluster(&event{Location: geo.NewPoint(3, 2)})
-
-	c1.Combine(c3)
+	c1 = CombineClusters(c1, c3)
 	if !c1.Centroid.Equals(geo.NewPoint(2.0, 1.0)) {
 		t.Errorf("centroid not adjusted correctly, got %v", c1.Centroid)
 	}

--- a/clustering/clustering_test.go
+++ b/clustering/clustering_test.go
@@ -56,7 +56,7 @@ func TestClusteringClusterClusters(t *testing.T) {
 	}
 }
 
-func TestGeoProjectedClusteringClusterClusters(t *testing.T) {
+func TestClusterGeoClusters(t *testing.T) {
 	preclusters, pointers := loadPrefilteredTestClusters(t)
 	bound := geo.NewBoundFromPoints(pointers[0].CenterPoint(), pointers[1].CenterPoint())
 	for _, p := range pointers {
@@ -64,7 +64,7 @@ func TestGeoProjectedClusteringClusterClusters(t *testing.T) {
 	}
 	bound.GeoPad(1) // for projection loop round off
 
-	clusters := ClusterClustersGeoProjected(preclusters, 30)
+	clusters := ClusterGeoClusters(preclusters, 30)
 
 	if l := len(clusters); l != 27 {
 		t.Errorf("incorrect number of clusters, got %d", l)
@@ -130,14 +130,28 @@ func BenchmarkClusterClusters(b *testing.B) {
 	}
 }
 
+// > go test -c && ./clustering.test -test.bench=ClusterPointers -test.cpuprofile=cpu.out -test.benchtime=10s
+// > go tool pprof clustering.test cpu.out
+func BenchmarkClusterPointers(b *testing.B) {
+	_, pointers := loadPrefilteredTestClusters(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cs := ClusterPointers(pointers, CentroidGeoDistance{}, 30)
+		if len(cs) != 26 {
+			b.Fatalf("incorrect number of clusters, got %v", len(cs))
+		}
+	}
+}
+
 // > go test -c && ./clustering.test -test.bench=PointClusteringGeoProjected -test.cpuprofile=cpu.out -test.benchtime=10s
 // > go tool pprof clustering.test cpu.out
-func BenchmarkPointClusteringGeoProjected(b *testing.B) {
+func BenchmarkClusterGeoClusters(b *testing.B) {
 	clusters, _ := loadPrefilteredTestClusters(b)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cs := ClusterClustersGeoProjected(clusters, 30)
+		cs := ClusterGeoClusters(clusters, 30)
 
 		if len(cs) != 27 {
 			b.Fatalf("incorrect number of clusters, got %v", len(cs))
@@ -145,7 +159,7 @@ func BenchmarkPointClusteringGeoProjected(b *testing.B) {
 	}
 }
 
-func BenchmarkInitializePointClusterDistances(b *testing.B) {
+func BenchmarkInitClusterDistances(b *testing.B) {
 	clusters, _ := loadPrefilteredTestClusters(b)
 
 	bound := geo.NewBoundFromPoints(clusters[0].Centroid, clusters[1].Centroid)
@@ -158,7 +172,7 @@ func BenchmarkInitializePointClusterDistances(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		initializeClusterDistances(clusters, CentroidSquaredDistance{}, threshold)
+		initClusterDistances(clusters, CentroidSquaredDistance{}, threshold)
 	}
 }
 

--- a/clustering/combiner.go
+++ b/clustering/combiner.go
@@ -4,11 +4,11 @@ import "math"
 
 // A Combiner is something that can be combined.
 type Combiner interface {
-	Combine(c Combiner)
+	Combine(c Combiner) Combiner
 	DistanceFromCombiner(c Combiner) float64
 }
 
-// CombineCombiners will do a simple hierarchical of the combiners.
+// ClusterCombiners will do a simple hierarchical of the combiners.
 // It will modify the input slice as things will be combined into each other.
 func ClusterCombiners(combiners []Combiner, threshold float64) []Combiner {
 	if len(combiners) < 2 {
@@ -30,7 +30,7 @@ func ClusterCombiners(combiners []Combiner, threshold float64) []Combiner {
 		}
 
 		// merge these two
-		combiners[lower].Combine(combiners[higher])
+		combiners[lower] = combiners[lower].Combine(combiners[higher])
 		s.ResetDistances(lower, higher)
 		combiners[higher] = nil
 	}

--- a/clustering/examples_test.go
+++ b/clustering/examples_test.go
@@ -45,7 +45,7 @@ func ExampleGeoPointClustering() {
 	}
 
 	threshold := 1.0 // meter
-	clusters := clustering.ClusterPointersGeoProjected(
+	clusters := clustering.ClusterGeoPointers(
 		pointers,
 		threshold,
 	)

--- a/clustering/helpers/prefilter_test.go
+++ b/clustering/helpers/prefilter_test.go
@@ -51,7 +51,7 @@ func BenchmarkPrefilteredGeoProjectedClustering(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		clusters := RemoveOutlierPointersByQuadkey(pointers, 24, 3)
-		clusters = clustering.ClusterClustersGeoProjected(clusters, 30)
+		clusters = clustering.ClusterGeoClusters(clusters, 30)
 
 		if l := len(clusters); l != 27 {
 			b.Errorf("incorrect number of clusters, got %v", l)


### PR DESCRIPTION
* Renamed functions to `ClusterGeoPointers` and `ClusterGeoClusters`
* Combining clusters creates a new cluster with the two original saved as its children. This allows traceback through the clustering hierarchy.

FYI @mlerner