### PR TITLE
Add Scan and UnmarshalWKB methods

### DIFF
--- a/benchmarks_wkb_test.go
+++ b/benchmarks_wkb_test.go
@@ -1,0 +1,95 @@
+package geo
+
+import "testing"
+
+func BenchmarkPointScan(b *testing.B) {
+	p := NewPoint(0, 0)
+	data := []uint8{1, 1, 0, 0, 0, 15, 152, 60, 227, 24, 157, 94, 192, 205, 11, 17, 39, 128, 222, 66, 64}
+	err := p.Scan(data)
+	if err != nil {
+		b.Fatalf("should scan without error, got %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Scan(data)
+	}
+}
+
+func BenchmarkPointUnmarshalWKB(b *testing.B) {
+	p := NewPoint(0, 0)
+	data := []uint8{1, 1, 0, 0, 0, 15, 152, 60, 227, 24, 157, 94, 192, 205, 11, 17, 39, 128, 222, 66, 64}
+	err := p.unmarshalWKB(data)
+	if err != nil {
+		b.Fatalf("should scan without error, got %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.unmarshalWKB(data)
+	}
+}
+
+func BenchmarkLineScan(b *testing.B) {
+	l := &Line{}
+	data := []byte{1, 2, 0, 0, 0, 2, 0, 0, 0, 213, 7, 146, 119, 14, 193, 94, 192, 93, 250, 151, 164, 50, 5, 67, 64, 26, 164, 224, 41, 228, 170, 94, 192, 22, 75, 145, 124, 37, 70, 67, 64}
+
+	err := l.Scan(data)
+	if err != nil {
+		b.Fatalf("should scan without error, got %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Scan(data)
+	}
+}
+
+func BenchmarkLineUnmarshalWKB(b *testing.B) {
+	l := &Line{}
+	data := []byte{1, 2, 0, 0, 0, 2, 0, 0, 0, 213, 7, 146, 119, 14, 193, 94, 192, 93, 250, 151, 164, 50, 5, 67, 64, 26, 164, 224, 41, 228, 170, 94, 192, 22, 75, 145, 124, 37, 70, 67, 64}
+
+	err := l.unmarshalWKB(data)
+	if err != nil {
+		b.Fatalf("should scan without error, got %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.unmarshalWKB(data)
+	}
+}
+
+func BenchmarkPathScan(b *testing.B) {
+	p := NewPath()
+
+	err := p.Scan(testPathWKB)
+	if err != nil {
+		b.Fatalf("should scan without error, got %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Scan(testPathWKB)
+	}
+}
+
+func BenchmarkPathUnmarshalWKB(b *testing.B) {
+	p := NewPath()
+
+	err := p.unmarshalWKB(testPathWKB)
+	if err != nil {
+		b.Fatalf("should scan without error, got %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.unmarshalWKB(testPathWKB)
+	}
+}

--- a/wkb.go
+++ b/wkb.go
@@ -1,0 +1,285 @@
+package geo
+
+import (
+	"errors"
+	"math"
+)
+
+var (
+	// ErrUnsupportedDataType is returned by Scan methods when asked to scan
+	// non []byte data from the database. This should never happen
+	// if the driver is acting appropriately.
+	ErrUnsupportedDataType = errors.New("go.geo: scan value must be []byte")
+
+	// ErrNotWKB is returned when unmarshalling WKB and the data is not valid.
+	ErrNotWKB = errors.New("go.geo: invalid WKB data")
+
+	// ErrIncorrectGeometry is returned when unmarshalling WKB data into the wrong type.
+	// For example, unmarshaling linestring data into a point.
+	ErrIncorrectGeometry = errors.New("go.geo: incorrect geometry")
+)
+
+// NewPointFromWKB will take raw WKB and set the data for a new point.
+// The WKB data must be of type Point. Will return nil if invalid WKB point.
+func NewPointFromWKB(wkb []byte) *Point {
+	p := &Point{}
+	if err := p.unmarshalWKB(wkb); err != nil {
+		return nil
+	}
+
+	return p
+}
+
+// NewLineFromWKB will take raw WKB and set the data for a new line.
+// The WKB data must of type LineString and only contain 2 points.
+// Will return nil if invalid WKB.
+func NewLineFromWKB(wkb []byte) *Line {
+	l := &Line{}
+	if err := l.unmarshalWKB(wkb); err != nil {
+		return nil
+	}
+
+	return l
+}
+
+// NewPointSetFromWKB will take raw WKB and set the data for a new point set.
+// The WKB data must be of type LineString, Polygon or MultiPoint.
+// Will return nil if invalid WKB.
+func NewPointSetFromWKB(wkb []byte) *PointSet {
+	ps := &PointSet{}
+	if err := ps.unmarshalWKB(wkb); err != nil {
+		return nil
+	}
+
+	return ps
+}
+
+// NewPathFromWKB will take raw WKB and set the data for a new path.
+// The WKB data must be of type LineString, Polygon or MultiPoint.
+// Will return nil if invalid WKB.
+func NewPathFromWKB(wkb []byte) *Path {
+	p := NewPath()
+	if err := p.PointSet.unmarshalWKB(wkb); err != nil {
+		return nil
+	}
+
+	return p
+}
+
+// Scan implements the sql.Scanner interface allowing
+// point structs to be passed into rows.Scan(...interface{})
+// The column must be of type Point and must be fetched in WKB format.
+// Will attempt to parse MySQL's SRID+WKB format if the data is of the right size.
+func (p *Point) Scan(value interface{}) error {
+	data, ok := value.([]byte)
+	if !ok {
+		return ErrUnsupportedDataType
+	}
+
+	if len(data) == 21 {
+		// the length of a point type in WKB
+		return p.unmarshalWKB(data)
+	}
+
+	if len(data) == 25 {
+		// Most likely MySQL's SRID+WKB format.
+		// However, could be a line string or multipoint with only one point.
+		// But those would be invalid for parsing a point.
+		return p.unmarshalWKB(data[4:])
+	}
+
+	return ErrIncorrectGeometry
+}
+
+func (p *Point) unmarshalWKB(data []byte) error {
+	if len(data) != 21 {
+		return ErrNotWKB
+	}
+
+	littleEndian, typeCode, err := scanPrefix(data)
+	if err != nil {
+		return err
+	}
+
+	if typeCode != 1 {
+		return ErrIncorrectGeometry
+	}
+
+	p[0] = scanFloat64(data[5:13], littleEndian)
+	p[1] = scanFloat64(data[13:21], littleEndian)
+
+	return nil
+}
+
+// Scan implements the sql.Scanner interface allowing
+// line structs to be passed into rows.Scan(...interface{})
+// The column must be of type LineString and contain 2 points,
+// or an error will be returned. Data must be fetched in WKB format.
+// Will attempt to parse MySQL's SRID+WKB format if the data is of the right size.
+func (l *Line) Scan(value interface{}) error {
+	data, ok := value.([]byte)
+	if !ok {
+		return ErrUnsupportedDataType
+	}
+
+	if len(data) == 41 {
+		// the length of a 2 point linestring type in WKB
+		return l.unmarshalWKB(data)
+	}
+
+	if len(data) == 45 {
+		// Most likely MySQL's SRID+WKB format.
+		// However, could be some encoding of another type.
+		// But those would be invalid for parsing a line.
+		return l.unmarshalWKB(data[4:])
+	}
+
+	return ErrIncorrectGeometry
+}
+
+func (l *Line) unmarshalWKB(data []byte) error {
+	if len(data) != 41 {
+		return ErrNotWKB
+	}
+
+	littleEndian, typeCode, err := scanPrefix(data)
+	if err != nil {
+		return err
+	}
+
+	if typeCode != 2 {
+		return ErrIncorrectGeometry
+	}
+
+	length := scanUint32(data[5:9], littleEndian)
+	if length != 2 {
+		return ErrIncorrectGeometry
+	}
+
+	l.a[0] = scanFloat64(data[9:17], littleEndian)
+	l.a[1] = scanFloat64(data[17:25], littleEndian)
+	l.b[0] = scanFloat64(data[25:33], littleEndian)
+	l.b[1] = scanFloat64(data[33:41], littleEndian)
+
+	return nil
+}
+
+// Scan implements the sql.Scanner interface allowing
+// line structs to be passed into rows.Scan(...interface{})
+// The column must be of type LineString, Polygon or MultiPoint
+// or an error will be returned. Data must be fetched in WKB format.
+// Will attempt to parse MySQL's SRID+WKB format if obviously no WKB
+// or parsing as WKB fails.
+func (ps *PointSet) Scan(value interface{}) error {
+	data, ok := value.([]byte)
+	if !ok {
+		return ErrUnsupportedDataType
+	}
+
+	if len(data) < 6 {
+		return ErrNotWKB
+	}
+
+	// first byte of real WKB data indicates endian and should 1 or 0.
+	if data[0] == 0 || data[0] == 1 {
+		if err := ps.unmarshalWKB(data); err == nil {
+			return nil
+		}
+	}
+
+	return ps.unmarshalWKB(data[4:])
+}
+
+func (ps *PointSet) unmarshalWKB(data []byte) error {
+	if len(data) < 6 {
+		return ErrNotWKB
+	}
+
+	littleEndian, typeCode, err := scanPrefix(data)
+	if err != nil {
+		return err
+	}
+
+	// must be LineString, Polygon or MultiPoint
+	if typeCode != 2 && typeCode != 3 && typeCode != 4 {
+		return ErrIncorrectGeometry
+	}
+
+	length := int(scanUint32(data[5:9], littleEndian))
+
+	if len(data) != 9+16*length {
+		return ErrNotWKB
+	}
+
+	points := make([]Point, length, length)
+	for i := 0; i < length; i++ {
+		points[i][0] = scanFloat64(data[9+i*16:9+i*16+8], littleEndian)
+		points[i][1] = scanFloat64(data[9+i*16+8:9+i*16+16], littleEndian)
+	}
+
+	ps.SetPoints(points)
+
+	return nil
+}
+
+// Scan implements the sql.Scanner interface allowing
+// line structs to be passed into rows.Scan(...interface{})
+// The column must be of type LineString, Polygon or MultiPoint
+// or an error will be returned. Data must be fetched in WKB format.
+// Will attempt to parse MySQL's SRID+WKB format if obviously no WKB
+// or parsing as WKB fails.
+func (p *Path) Scan(value interface{}) error {
+	return p.PointSet.Scan(value)
+}
+
+func scanPrefix(data []byte) (bool, uint32, error) {
+	if len(data) < 6 {
+		return false, 0, ErrNotWKB
+	}
+
+	if data[0] == 0 {
+		return false, scanUint32(data[1:5], false), nil
+	}
+
+	if data[0] == 1 {
+		return true, scanUint32(data[1:5], true), nil
+	}
+
+	return false, 0, ErrNotWKB
+}
+
+func scanUint32(data []byte, littleEndian bool) uint32 {
+	var v uint32
+
+	if littleEndian {
+		for i := 3; i >= 0; i-- {
+			v <<= 8
+			v |= uint32(data[i])
+		}
+	} else {
+		for i := 0; i < 4; i++ {
+			v <<= 8
+			v |= uint32(data[i])
+		}
+	}
+
+	return v
+}
+
+func scanFloat64(data []byte, littleEndian bool) float64 {
+	var v uint64
+
+	if littleEndian {
+		for i := 7; i >= 0; i-- {
+			v <<= 8
+			v |= uint64(data[i])
+		}
+	} else {
+		for i := 0; i < 8; i++ {
+			v <<= 8
+			v |= uint64(data[i])
+		}
+	}
+
+	return math.Float64frombits(v)
+}

--- a/wkb_test.go
+++ b/wkb_test.go
@@ -1,0 +1,258 @@
+package geo
+
+import "testing"
+
+var testPathWKB = []byte{1, 2, 0, 0, 0, 6, 0, 0, 0, 205, 228, 155, 109, 110, 114, 87, 192, 174, 158, 147, 222, 55, 50, 64, 64, 134, 56, 214, 197, 109, 114, 87, 192, 238, 235, 192, 57, 35, 50, 64, 64, 173, 47, 18, 218, 114, 114, 87, 192, 25, 4, 86, 14, 45, 50, 64, 64, 10, 75, 60, 160, 108, 114, 87, 192, 224, 161, 40, 208, 39, 50, 64, 64, 149, 159, 84, 251, 116, 114, 87, 192, 96, 147, 53, 234, 33, 50, 64, 64, 195, 158, 118, 248, 107, 114, 87, 192, 89, 139, 79, 1, 48, 50, 64, 64}
+
+func TestPointScan(t *testing.T) {
+	p := NewPoint(0, 0)
+
+	if err := p.Scan(123); err != ErrUnsupportedDataType {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	// regular WKB data
+	err := p.Scan([]byte{1, 1, 0, 0, 0, 253, 104, 56, 101, 110, 114, 87, 192, 192, 9, 133, 8, 56, 50, 64, 64})
+	if err != nil {
+		t.Errorf("should not get error, got %v", err)
+	}
+
+	if !p.Equals(NewPoint(-93.787988, 32.392335)) {
+		t.Errorf("incorrect point, got %v", p)
+	}
+
+	// mysql's SRID+WKB data
+	err = p.Scan([]byte{215, 15, 0, 0, 1, 1, 0, 0, 0, 107, 153, 12, 199, 243, 170, 94, 192, 25, 200, 179, 203, 183, 22, 67, 64})
+	if err != nil {
+		t.Errorf("should not get error, got %v", err)
+	}
+
+	if !p.Equals(NewPoint(-122.671129, 38.177484)) {
+		t.Errorf("incorrect point, got %v", p)
+	}
+}
+
+func TestPointUnmarshalWKB(t *testing.T) {
+	p := NewPoint(0, 0)
+
+	type testData struct {
+		x, y float64
+		data []byte
+	}
+
+	tests := []testData{
+		testData{ // little endian
+			x: -122.4546440212, y: 37.7382859071,
+			data: []byte{1, 1, 0, 0, 0, 15, 152, 60, 227, 24, 157, 94, 192, 205, 11, 17, 39, 128, 222, 66, 64},
+		},
+		testData{ // big endian
+			x: -122.4546440212, y: 37.7382859071,
+			data: []byte{0, 0, 0, 0, 1, 192, 94, 157, 24, 227, 60, 152, 15, 64, 66, 222, 128, 39, 17, 11, 205},
+		},
+		testData{
+			x: -93.787988, y: 32.392335,
+			data: []byte{1, 1, 0, 0, 0, 253, 104, 56, 101, 110, 114, 87, 192, 192, 9, 133, 8, 56, 50, 64, 64},
+		},
+	}
+
+	for i, test := range tests {
+		err := p.unmarshalWKB(test.data)
+		if err != nil {
+			t.Errorf("test %d had error %v", i, err)
+		}
+
+		if test.x != p[0] {
+			t.Errorf("test %d incorrect x, got %v", i, p[0])
+		}
+
+		if test.y != p[1] {
+			t.Errorf("test %d incorrect y, got %v", i, p[1])
+		}
+	}
+
+	// error conditions
+	err := p.unmarshalWKB([]byte{0, 0, 0, 0, 1, 192, 94, 157, 24, 227, 60, 152, 15, 64, 66, 222, 128, 39})
+	if err != ErrNotWKB {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	err = p.unmarshalWKB([]byte{3, 1, 0, 0, 0, 15, 152, 60, 227, 24, 157, 94, 192, 205, 11, 17, 39, 128, 222, 66, 64})
+	if err != ErrNotWKB {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	err = p.unmarshalWKB([]byte{0, 2, 0, 0, 0, 15, 152, 60, 227, 24, 157, 94, 192, 205, 11, 17, 39, 128, 222, 66, 64})
+	if err != ErrIncorrectGeometry {
+		t.Errorf("incorrect error, got %v", err)
+	}
+}
+
+func TestLineScan(t *testing.T) {
+	l := &Line{}
+
+	if err := l.Scan(123); err != ErrUnsupportedDataType {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	// regular WKB data
+	err := l.Scan([]byte{1, 2, 0, 0, 0, 2, 0, 0, 0, 213, 7, 146, 119, 14, 193, 94, 192, 93, 250, 151, 164, 50, 5, 67, 64, 26, 164, 224, 41, 228, 170, 94, 192, 22, 75, 145, 124, 37, 70, 67, 64})
+	if err != nil {
+		t.Errorf("should not get error, got %v", err)
+	}
+
+	if !l.Equals(NewLine(NewPoint(-123.016508, 38.040608), NewPoint(-122.670176, 38.548019))) {
+		t.Errorf("incorrect line, got %v", l)
+	}
+
+	// mysql's SRID+WKB data
+	err = l.Scan([]byte{215, 15, 0, 0, 1, 2, 0, 0, 0, 2, 0, 0, 0, 213, 7, 146, 119, 14, 193, 94, 192, 93, 250, 151, 164, 50, 5, 67, 64, 26, 164, 224, 41, 228, 170, 94, 192, 22, 75, 145, 124, 37, 70, 67, 64})
+	if err != nil {
+		t.Errorf("should not get error, got %v", err)
+	}
+
+	if !l.Equals(NewLine(NewPoint(-123.016508, 38.040608), NewPoint(-122.670176, 38.548019))) {
+		t.Errorf("incorrect line, got %v", l)
+	}
+}
+
+func TestLineUnmarshalWKB(t *testing.T) {
+	l := &Line{}
+
+	type testData struct {
+		line *Line
+		data []byte
+	}
+
+	tests := []testData{
+		testData{
+			line: NewLine(NewPoint(-123.016508, 38.040608), NewPoint(-122.670176, 38.548019)),
+			data: []byte{1, 2, 0, 0, 0, 2, 0, 0, 0, 213, 7, 146, 119, 14, 193, 94, 192, 93, 250, 151, 164, 50, 5, 67, 64, 26, 164, 224, 41, 228, 170, 94, 192, 22, 75, 145, 124, 37, 70, 67, 64},
+		},
+		testData{
+			line: NewLine(NewPoint(-72.796408, -45.407131), NewPoint(-72.688541, -45.384987)),
+			data: []byte{1, 2, 0, 0, 0, 2, 0, 0, 0, 117, 145, 66, 89, 248, 50, 82, 192, 9, 24, 93, 222, 28, 180, 70, 192, 33, 61, 69, 14, 17, 44, 82, 192, 77, 49, 7, 65, 71, 177, 70, 192},
+		},
+	}
+
+	for i, test := range tests {
+		err := l.unmarshalWKB(test.data)
+		if err != nil {
+			t.Errorf("test %d had error %v", i, err)
+		}
+
+		if !l.Equals(test.line) {
+			t.Errorf("test %d incorrect line, got %v", i, l)
+		}
+	}
+
+	// error conditions
+	err := l.unmarshalWKB([]byte{0, 0, 0, 0, 1, 192, 94, 157, 24, 227, 60, 152, 15, 64, 66, 222, 128, 39})
+	if err != ErrNotWKB {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	err = l.unmarshalWKB([]byte{3, 1, 0, 0, 0, 15, 152, 60, 227, 24, 157, 94, 192, 205, 11, 17, 39, 128, 222, 66, 64})
+	if err != ErrNotWKB {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	err = l.unmarshalWKB([]byte{1, 1, 0, 0, 0, 2, 0, 0, 0, 213, 7, 146, 119, 14, 193, 94, 192, 93, 250, 151, 164, 50, 5, 67, 64, 26, 164, 224, 41, 228, 170, 94, 192, 22, 75, 145, 124, 37, 70, 67, 64})
+	if err != ErrIncorrectGeometry {
+		t.Errorf("incorrect error, got %v", err)
+	}
+}
+
+func TestPathScan(t *testing.T) {
+	path := NewPath()
+
+	if err := path.Scan(123); err != ErrUnsupportedDataType {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	// regular WKB data
+	err := path.Scan(testPathWKB)
+	if err != nil {
+		t.Errorf("should not get error, got %v", err)
+	}
+
+	// mysql's SRID+WKB data
+	err = path.Scan(append([]byte{215, 15, 0, 0}, testPathWKB...))
+	if err != nil {
+		t.Errorf("should not get error, got %v", err)
+	}
+}
+
+func TestPathUnmarshalWKB(t *testing.T) {
+	type testData struct {
+		path *Path
+		data []byte
+	}
+
+	path := NewPath().
+		Push(NewPoint(-93.78799, 32.39233)).Push(NewPoint(-93.78795, 32.3917)).Push(NewPoint(-93.78826, 32.392)).
+		Push(NewPoint(-93.78788, 32.39184)).Push(NewPoint(-93.78839, 32.39166)).Push(NewPoint(-93.78784, 32.39209))
+
+	tests := []testData{
+		testData{
+			path: path,
+			data: testPathWKB,
+		},
+	}
+
+	for i, test := range tests {
+		p := NewPath()
+
+		err := p.unmarshalWKB(test.data)
+		if err != nil {
+			t.Errorf("test %d had error %v", i, err)
+		}
+
+		if !p.Equals(test.path) {
+			t.Errorf("test %d incorrect path, got %v", i, p)
+		}
+	}
+
+	// error conditions
+	err := path.unmarshalWKB([]byte{0, 0, 0, 0, 1})
+	if err != ErrNotWKB {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	err = path.unmarshalWKB([]byte{3, 1, 0, 0, 0, 15, 152, 60, 227, 24, 157, 94, 192, 205, 11, 17, 39, 128, 222, 66, 64})
+	if err != ErrNotWKB {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	err = path.unmarshalWKB([]byte{1, 1, 0, 0, 0, 2, 0, 0, 0, 213, 7, 146, 119, 14, 193, 94, 192, 93, 250, 151, 164, 50, 5, 67, 64, 26, 164, 224, 41, 228, 170, 94, 192, 22, 75, 145, 124, 37, 70, 67, 64})
+	if err != ErrIncorrectGeometry {
+		t.Errorf("incorrect error, got %v", err)
+	}
+}
+
+func TestScanUint32(t *testing.T) {
+	if v := scanUint32([]byte{1, 0, 0, 0}, true); v != 1 {
+		t.Errorf("parsed to wrong value, got %v", v)
+	}
+
+	if v := scanUint32([]byte{1, 0, 0, 1}, true); v != 16777217 {
+		t.Errorf("parsed to wrong value, got %v", v)
+	}
+
+	if v := scanUint32([]byte{1, 0, 0, 0}, false); v != 16777216 {
+		t.Errorf("parsed to wrong value, got %v", v)
+	}
+}
+
+func TestScanFloat64(t *testing.T) {
+	if v := scanFloat64([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0}, true); v != 0 {
+		t.Errorf("parsed to wrong value, got %v", v)
+	}
+
+	if v := scanFloat64([]byte{192, 94, 157, 24, 227, 60, 152, 15}, false); v != -122.4546440212 {
+		t.Errorf("parsed to wrong value, got %v", v)
+	}
+
+	if v := scanFloat64([]byte{15, 152, 60, 227, 24, 157, 94, 192}, true); v != -122.4546440212 {
+		t.Errorf("parsed to wrong value, got %v", v)
+	}
+}


### PR DESCRIPTION
Scan implements the [sql.Scanner](http://golang.org/pkg/database/sql/#Scanner) interface allowing points, lines, point sets and paths to be passed into rows.Scan(…interface{}) calls. This simplifies working with the database a long.

Basically allows you to do stuff like
```
row := db.QueryRow("SELECT AsBinary(point_column) FROM table")

var p *geo.Point
row.Scan(&p)
```

Note that you need to wrap the column in `AsBinary`

@mlerner 