### PR TITLE
clustering.Pointer -> geo.Pointer

### DIFF
--- a/clustering/cluster.go
+++ b/clustering/cluster.go
@@ -2,24 +2,15 @@ package clustering
 
 import "github.com/paulmach/go.geo"
 
-// A Pointer is the interface for something that can be point clustered.
-// Basically anything that can be boiled down to a single point.
-type Pointer interface {
-	// CenterPoint is kind of a weird name, but it's meant to not overlap
-	// with any stuct attributes.
-	CenterPoint() *geo.Point // lng/lat, or other, point
-}
-
 // A Cluster is a cluster of pointers plus their centroid.
 // It defines a center/centroid for easy centroid distance computation.
 type Cluster struct {
 	Centroid *geo.Point
-	Pointers []Pointer
-	Parents  [2]*Cluster // can be used to trace down the clustering tree.
+	Pointers []geo.Pointer
 }
 
 // NewCluster creates the point cluster and finds the center of the given pointers.
-func NewCluster(pointers ...Pointer) *Cluster {
+func NewCluster(pointers ...geo.Pointer) *Cluster {
 	var (
 		sumX, sumY float64
 		count      int
@@ -35,13 +26,13 @@ func NewCluster(pointers ...Pointer) *Cluster {
 	}
 
 	if len(pointers) == 1 {
-		c.Centroid = pointers[0].CenterPoint().Clone()
+		c.Centroid = pointers[0].Point().Clone()
 		return c
 	}
 
 	// find the center/centroid of multiple points
 	for _, pointer := range c.Pointers {
-		cp := pointer.CenterPoint()
+		cp := pointer.Point()
 
 		sumX += cp.X()
 		sumY += cp.Y()
@@ -54,19 +45,18 @@ func NewCluster(pointers ...Pointer) *Cluster {
 
 // NewClusterWithCentroid creates a point cluster stub from the given centroid
 // and optional pointers.
-func NewClusterWithCentroid(centroid *geo.Point, pointers ...Pointer) *Cluster {
+func NewClusterWithCentroid(centroid *geo.Point, pointers ...geo.Pointer) *Cluster {
 	return &Cluster{
 		Centroid: centroid.Clone(),
 		Pointers: pointers,
 	}
 }
 
-// CombineClusters merges the given point clusters and creates a new one.
-// Sets c1 and c2 as the children of the new cluster for tracing back down the tree.
-func CombineClusters(c1, c2 *Cluster) *Cluster {
-	return &Cluster{
-		Centroid: geo.NewLine(c1.Centroid, c2.Centroid).Interpolate(1 - float64(len(c1.Pointers))/float64(len(c2.Pointers)+len(c1.Pointers))),
-		Pointers: append(c1.Pointers, c2.Pointers...),
-		Parents:  [2]*Cluster{c1, c2},
-	}
+func (c *Cluster) merge(c2 *Cluster) {
+
+	percent := 1 - float64(len(c.Pointers))/float64(len(c.Pointers)+len(c2.Pointers))
+
+	c.Centroid.SetX(c.Centroid[0] + percent*(c2.Centroid[0]-c.Centroid[0]))
+	c.Centroid.SetY(c.Centroid[1] + percent*(c2.Centroid[1]-c.Centroid[1]))
+	c.Pointers = append(c.Pointers, c2.Pointers...)
 }

--- a/clustering/cluster_test.go
+++ b/clustering/cluster_test.go
@@ -21,7 +21,7 @@ func TestNewCluster(t *testing.T) {
 	// one pointer
 	c1 = NewCluster(&event{Location: geo.NewPoint(1, 0)})
 
-	if c1.Centroid == c1.Pointers[0].CenterPoint() {
+	if c1.Centroid == c1.Pointers[0].Point() {
 		t.Errorf("should make a copy for center point")
 	}
 
@@ -67,7 +67,7 @@ func TestCombineClusters(t *testing.T) {
 	c1 := NewCluster(&event{Location: geo.NewPoint(1, 0)})
 	c2 := NewCluster(&event{Location: geo.NewPoint(2, 1)})
 
-	c1 = CombineClusters(c1, c2)
+	c1.merge(c2)
 	if !c1.Centroid.Equals(geo.NewPoint(1.5, 0.5)) {
 		t.Errorf("centroid not adjusted correctly, got %v", c1.Centroid)
 	}
@@ -77,7 +77,7 @@ func TestCombineClusters(t *testing.T) {
 	}
 
 	c3 := NewCluster(&event{Location: geo.NewPoint(3, 2)})
-	c1 = CombineClusters(c1, c3)
+	c1.merge(c3)
 	if !c1.Centroid.Equals(geo.NewPoint(2.0, 1.0)) {
 		t.Errorf("centroid not adjusted correctly, got %v", c1.Centroid)
 	}

--- a/clustering/clustering.go
+++ b/clustering/clustering.go
@@ -8,7 +8,7 @@ import (
 
 // ClusterPointers will take a set of Pointers and cluster them using
 // the distancer and threshold.
-func ClusterPointers(pointers []Pointer, distancer ClusterDistancer, threshold float64) []*Cluster {
+func ClusterPointers(pointers []geo.Pointer, distancer ClusterDistancer, threshold float64) []*Cluster {
 	clusters := make([]*Cluster, 0, len(pointers))
 	for _, p := range pointers {
 		clusters = append(clusters, NewCluster(p))
@@ -61,7 +61,7 @@ func cluster(clusters []*Cluster, distancer ClusterDistancer, threshold float64)
 // It will project the points using mercator, scale the threshold, cluster, and project back.
 // Performace is about 40% than simply using a geo distancer.
 // This may not make sense for all geo datasets.
-func ClusterGeoPointers(pointers []Pointer, threshold float64) []*Cluster {
+func ClusterGeoPointers(pointers []geo.Pointer, threshold float64) []*Cluster {
 	clusters := make([]*Cluster, 0, len(pointers))
 	for _, p := range pointers {
 		clusters = append(clusters, NewCluster(p))
@@ -184,7 +184,7 @@ func clusterClusters(
 		}
 
 		// merge these two
-		clusters[lower] = CombineClusters(clusters[lower], clusters[higher])
+		clusters[lower].merge(clusters[higher])
 		s.ResetDistances(lower, higher)
 		clusters[higher] = nil
 

--- a/clustering/clustering_test.go
+++ b/clustering/clustering_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestClusteringClusterClusters(t *testing.T) {
 	preclusters, pointers := loadPrefilteredTestClusters(t)
-	bound := geo.NewBoundFromPoints(pointers[0].CenterPoint(), pointers[1].CenterPoint())
+	bound := geo.NewBoundFromPoints(pointers[0].Point(), pointers[1].Point())
 	for _, p := range pointers {
-		bound.Extend(p.CenterPoint())
+		bound.Extend(p.Point())
 	}
 	bound.GeoPad(1) // for round off
 
@@ -49,8 +49,8 @@ func TestClusteringClusterClusters(t *testing.T) {
 		}
 
 		for _, pointer := range c.Pointers {
-			if !bound.Contains(pointer.CenterPoint()) {
-				t.Errorf("pointer must at least be within original bound, got %v", pointer.CenterPoint())
+			if !bound.Contains(pointer.Point()) {
+				t.Errorf("pointer must at least be within original bound, got %v", pointer.Point())
 			}
 		}
 	}
@@ -58,9 +58,9 @@ func TestClusteringClusterClusters(t *testing.T) {
 
 func TestClusterGeoClusters(t *testing.T) {
 	preclusters, pointers := loadPrefilteredTestClusters(t)
-	bound := geo.NewBoundFromPoints(pointers[0].CenterPoint(), pointers[1].CenterPoint())
+	bound := geo.NewBoundFromPoints(pointers[0].Point(), pointers[1].Point())
 	for _, p := range pointers {
-		bound.Extend(p.CenterPoint())
+		bound.Extend(p.Point())
 	}
 	bound.GeoPad(1) // for projection loop round off
 
@@ -96,8 +96,8 @@ func TestClusterGeoClusters(t *testing.T) {
 		}
 
 		for _, pointer := range c.Pointers {
-			if !bound.Contains(pointer.CenterPoint()) {
-				t.Errorf("pointer must at least be within original bound, got %v", pointer.CenterPoint())
+			if !bound.Contains(pointer.Point()) {
+				t.Errorf("pointer must at least be within original bound, got %v", pointer.Point())
 			}
 		}
 	}
@@ -109,8 +109,8 @@ func TestClusterGeoClusters(t *testing.T) {
 		}
 
 		for _, pointer := range c.Pointers {
-			if !bound.Contains(pointer.CenterPoint()) {
-				t.Errorf("pointer must at least be within original bound, got %v", pointer.CenterPoint())
+			if !bound.Contains(pointer.Point()) {
+				t.Errorf("pointer must at least be within original bound, got %v", pointer.Point())
 			}
 		}
 	}
@@ -180,7 +180,7 @@ func BenchmarkInitClusterDistances(b *testing.B) {
 	}
 }
 
-func loadPrefilteredTestClusters(tb testing.TB) ([]*Cluster, []Pointer) {
+func loadPrefilteredTestClusters(tb testing.TB) ([]*Cluster, []geo.Pointer) {
 	f, err := os.Open("testdata/prefiltered.json.gz")
 	if err != nil {
 		tb.Fatalf("unable to open test file %v", err)
@@ -201,7 +201,7 @@ func loadPrefilteredTestClusters(tb testing.TB) ([]*Cluster, []Pointer) {
 
 	var clusters []*Cluster
 	for _, s := range sets {
-		var pointers []Pointer
+		var pointers []geo.Pointer
 		for _, p := range s {
 			pointers = append(pointers, &event{Location: p})
 		}
@@ -209,7 +209,7 @@ func loadPrefilteredTestClusters(tb testing.TB) ([]*Cluster, []Pointer) {
 		clusters = append(clusters, NewCluster(pointers...))
 	}
 
-	var pointers []Pointer
+	var pointers []geo.Pointer
 	for _, c := range clusters {
 		pointers = append(pointers, c.Pointers...)
 	}
@@ -221,6 +221,6 @@ type event struct {
 	Location *geo.Point
 }
 
-func (e *event) CenterPoint() *geo.Point {
+func (e *event) Point() *geo.Point {
 	return e.Location
 }

--- a/clustering/examples_test.go
+++ b/clustering/examples_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExamplePointClustering() {
-	pointers := []clustering.Pointer{
+	pointers := []geo.Pointer{
 		&Event{Location: geo.NewPoint(1, 1)},
 		&Event{Location: geo.NewPoint(2, 2)},
 		&Event{Location: geo.NewPoint(5, 5)},
@@ -36,7 +36,7 @@ func ExamplePointClustering() {
 }
 
 func ExampleGeoPointClustering() {
-	pointers := []clustering.Pointer{
+	pointers := []geo.Pointer{
 		&Event{Location: geo.NewPoint(-122.548081, 37.905995)},
 		&Event{Location: geo.NewPoint(-122.548091, 37.905987)},
 		&Event{Location: geo.NewPoint(-122.54807, 37.905995)},
@@ -73,6 +73,6 @@ type Event struct {
 	Location *geo.Point
 }
 
-func (e *Event) CenterPoint() *geo.Point {
+func (e *Event) Point() *geo.Point {
 	return e.Location
 }

--- a/clustering/helpers/filter_test.go
+++ b/clustering/helpers/filter_test.go
@@ -46,6 +46,6 @@ type event struct {
 	Location *geo.Point
 }
 
-func (e *event) CenterPoint() *geo.Point {
+func (e *event) Point() *geo.Point {
 	return e.Location
 }

--- a/clustering/helpers/prefilter.go
+++ b/clustering/helpers/prefilter.go
@@ -1,14 +1,17 @@
 package helpers
 
-import "github.com/paulmach/go.geo/clustering"
+import (
+	"github.com/paulmach/go.geo"
+	"github.com/paulmach/go.geo/clustering"
+)
 
 // RemoveOutlierPointersByQuadkey will bucket all pointers by quad key (defined by the level)
 // and remove the buckets with less than threshold pointers. The buckets become the resulting point_clustering.Clusters.
-func RemoveOutlierPointersByQuadkey(pointers []clustering.Pointer, level, threshold int) []*clustering.Cluster {
+func RemoveOutlierPointersByQuadkey(pointers []geo.Pointer, level, threshold int) []*clustering.Cluster {
 
-	buckets := make(map[int64][]clustering.Pointer)
+	buckets := make(map[int64][]geo.Pointer)
 	for _, p := range pointers {
-		key := p.CenterPoint().Quadkey(level)
+		key := p.Point().Quadkey(level)
 
 		buckets[key] = append(buckets[key], p)
 	}

--- a/clustering/helpers/prefilter_test.go
+++ b/clustering/helpers/prefilter_test.go
@@ -59,7 +59,7 @@ func BenchmarkPrefilteredGeoProjectedClustering(b *testing.B) {
 	}
 }
 
-func loadTestPointers(tb testing.TB) []clustering.Pointer {
+func loadTestPointers(tb testing.TB) []geo.Pointer {
 	f, err := os.Open("../testdata/points.csv.gz")
 	if err != nil {
 		tb.Fatalf("unable to open test file %v", err)
@@ -73,7 +73,7 @@ func loadTestPointers(tb testing.TB) []clustering.Pointer {
 	defer gzReader.Close()
 
 	// read in events
-	var pointers []clustering.Pointer
+	var pointers []geo.Pointer
 	scanner := bufio.NewScanner(gzReader)
 	for scanner.Scan() {
 		parts := strings.Split(scanner.Text(), ",")

--- a/clustering/helpers/rematch.go
+++ b/clustering/helpers/rematch.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"math"
 
+	"github.com/paulmach/go.geo"
 	"github.com/paulmach/go.geo/clustering"
 )
 
@@ -11,7 +12,7 @@ import (
 // Will return a new list.
 func RematchPointersToClusters(
 	clusters []*clustering.Cluster,
-	pointers []clustering.Pointer,
+	pointers []geo.Pointer,
 	distancer clustering.ClusterDistancer,
 	threshold float64,
 ) []*clustering.Cluster {

--- a/clustering/helpers/rematch_test.go
+++ b/clustering/helpers/rematch_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRematchPointersToClusters(t *testing.T) {
-	c := RematchPointersToClusters([]*clustering.Cluster{}, []clustering.Pointer{}, clustering.CentroidGeoDistance{}, 30)
+	c := RematchPointersToClusters([]*clustering.Cluster{}, []geo.Pointer{}, clustering.CentroidGeoDistance{}, 30)
 	if c == nil {
 		t.Errorf("result should not be nil")
 	}
@@ -22,7 +22,7 @@ func TestRematchPointersToClusters(t *testing.T) {
 		clustering.NewClusterWithCentroid(geo.NewPoint(2, 2)),
 	}
 
-	testPointers := []clustering.Pointer{
+	testPointers := []geo.Pointer{
 		&event{Location: geo.NewPoint(1, 1)},
 		&event{Location: geo.NewPoint(1, 1)},
 		&event{Location: geo.NewPoint(2, 2)},


### PR DESCRIPTION
This is a backwards incompatible change to use a common `Pointer`
interface between all sub packages. It also stops saving clustering
history, which is another incompatible change, but I’m not sure anyone
is using that.

Benchmarks slightly improved:
```
benchmark                           old ns/op      new ns/op      delta
BenchmarkClusterPointers-4          4181603714     3786866583     -9.44%
BenchmarkClusterGeoClusters-4       82982248       81037175       -2.34%
BenchmarkInitClusterDistances-4     24723068       24035114       -2.78%

benchmark                           old allocs     new allocs     delta
BenchmarkClusterPointers-4          271126         266437         -1.73%
BenchmarkClusterGeoClusters-4       5608           4547          -18.92%
BenchmarkInitClusterDistances-4     2057           2062           +0.24%

benchmark                           old bytes     new bytes     delta
BenchmarkClusterPointers-4          325818592     325616704     -0.06%
BenchmarkClusterGeoClusters-4       11866406      11823329      -0.36%
BenchmarkInitClusterDistances-4     11435860      11436147      +0.00%
```

@mlerner 