### PR TITLE
preallocate nodes in quadtree constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ after_script:
 script:
   - go test -v .
   - go test -v ./reducers/
+  - go test -v ./quadtree/
+  - go test -v ./clustering/

--- a/quadtree/quadtree.go
+++ b/quadtree/quadtree.go
@@ -46,19 +46,23 @@ type node struct {
 
 // New creates a new quadtree for the given bound. Added points
 // must be within this bound.
-func New(bound *geo.Bound) *Quadtree {
-	return &Quadtree{
+func New(bound *geo.Bound, preallocateSize ...int) *Quadtree {
+	qt := &Quadtree{
 		Threshold: math.Max(bound.Width(), bound.Height()) / float64(1<<12),
 		bound:     bound,
 	}
+	if len(preallocateSize) == 1 {
+		qt.freeNodes = make([]node, preallocateSize[0], preallocateSize[0])
+
+	}
+	return qt
 }
 
 // NewFromPointSet creates a quadtree from a pointset.
 // Copies the points into the quad tree. Modifying the points later
 // will invalidate the quad tree and lead to unexpected result.
 func NewFromPointSet(set *geo.PointSet) *Quadtree {
-	q := New(set.Bound())
-	q.freeNodes = make([]node, set.Length(), set.Length())
+	q := New(set.Bound(), set.Length())
 
 	ps := []geo.Point(*set)
 	for i := range ps {
@@ -81,8 +85,7 @@ func NewFromPointers(points []geo.Pointer) *Quadtree {
 		b.Extend(p.Point())
 	}
 
-	q := New(b)
-	q.freeNodes = make([]node, len(points), len(points))
+	q := New(b, len(points))
 
 	for _, p := range points {
 		q.Insert(p)

--- a/quadtree/quadtree_test.go
+++ b/quadtree/quadtree_test.go
@@ -15,6 +15,16 @@ func TestNew(t *testing.T) {
 		t.Errorf("should use provided bound, got %v", qt.Bound)
 	}
 
+	if qt.freeNodes != nil {
+		t.Errorf("freeNodes should not be preallocated")
+	}
+
+	qt = New(bound, 12)
+
+	if len(qt.freeNodes) != 12 {
+		t.Errorf("should preallocate %d freeNodes", 12)
+	}
+
 	ps := geo.NewPointSet()
 	ps.Push(geo.NewPoint(0, 2))
 	ps.Push(geo.NewPoint(1, 3))
@@ -22,6 +32,10 @@ func TestNew(t *testing.T) {
 	qt = NewFromPointSet(ps)
 	if !qt.Bound().Equals(ps.Bound()) {
 		t.Errorf("should take bound from pointset, got %v", qt.Bound())
+	}
+
+	if len(qt.freeNodes) != ps.Length() {
+		t.Errorf("should preallocate %d freeNodes", ps.Length())
 	}
 }
 


### PR DESCRIPTION
Make preallocating  freeNodes accesible for public usage. It is useful for filling quadtree by custom pointers.
