### PR TITLE
Add quadtree.FindMatching(Point, Filter) method

### DIFF
--- a/quadtree/quadtree_test.go
+++ b/quadtree/quadtree_test.go
@@ -12,7 +12,7 @@ func TestNew(t *testing.T) {
 	qt := New(bound)
 
 	if qt.Bound() != bound {
-		t.Errorf("should use provided bound, got %v", qt.Bound)
+		t.Errorf("should use provided bound, got %v", qt.Bound())
 	}
 
 	if qt.freeNodes != nil {

--- a/quadtree/quadtree_test.go
+++ b/quadtree/quadtree_test.go
@@ -94,6 +94,42 @@ func TestQuadtreeFindRandom(t *testing.T) {
 	}
 }
 
+func TestQuadtreeFindMatching(t *testing.T) {
+	type dataPointer struct {
+		geo.Pointer
+		visible bool
+	}
+
+	q := NewFromPointers([]geo.Pointer{
+		dataPointer{geo.NewPoint(0, 0), false},
+		dataPointer{geo.NewPoint(1, 1), true},
+	})
+
+	// filters
+	filters := map[bool]Filter{
+		false: nil,
+		true:  func(p geo.Pointer) bool { return p.(dataPointer).visible },
+	}
+
+	// table test
+	type findTest struct {
+		Filtered bool
+		Point    *geo.Point
+		Expected *geo.Point
+	}
+
+	tests := []findTest{
+		{Filtered: false, Point: geo.NewPoint(0.1, 0.1), Expected: geo.NewPoint(0, 0)},
+		{Filtered: true, Point: geo.NewPoint(0.1, 0.1), Expected: geo.NewPoint(1, 1)},
+	}
+
+	for i, test := range tests {
+		if v := q.FindMatching(test.Point, filters[test.Filtered]); !v.Point().Equals(test.Expected) {
+			t.Errorf("incorrect point on %d, got %v", i, v)
+		}
+	}
+}
+
 func TestQuadtreeInBoundRandom(t *testing.T) {
 	r := rand.New(rand.NewSource(43))
 


### PR DESCRIPTION
First of all, thank you for this library! We are using it (go.geo/quadtree specifically) for several store locators for our clients, and it is by far the best quadtree implementation we've found.

## Our need
In our use case, we need to search a quadtree for the nearest geo.Pointer which satisfies several conditions (think opening hours, product availability and similar criteria).

## quadtree.FindMatching
We therefore implemented `quadtree.FindMatching(*geo.Point, Filter)`, where `type Filter func(geo.Pointer) bool`.

This function is a variation of `quadtree.Find(*geo.Pointer)` which allows the user to provide a custom filter. The filter func will be called while visiting each pointer and must return a boolean value indicating if this pointer is to be considered or not. Since the two functions are very similar, Find has been reimplemented as a simple call to FindMatching with a nil Filter argument.

## Performance
The performance impact on a normal Find should be neglegible, since it only adds a nil-check [here](https://github.com/paulmach/go.geo/pull/54/files#diff-6965b51669cbe9fb18e2b26f66c2a1e0R367). The following benchmarks were run with Go 1.8.3 linux/amd64:

```
Before:
BenchmarkRandomFind1000-4        	 2000000	       705 ns/op	     112 B/op	       5 allocs/op
BenchmarkRandomFind1000-4        	 2000000	       718 ns/op	     112 B/op	       5 allocs/op
BenchmarkRandomFind1000-4        	 2000000	       712 ns/op	     112 B/op	       5 allocs/op

After:
BenchmarkRandomFind1000-4        	 2000000	       716 ns/op	     112 B/op	       5 allocs/op
BenchmarkRandomFind1000-4        	 2000000	       712 ns/op	     112 B/op	       5 allocs/op
BenchmarkRandomFind1000-4        	 2000000	       709 ns/op	     112 B/op	       5 allocs/op
```

The performance of FindMatching will obviously depend on the performance of the Filter function.

## Tests and documentation
Tests and GoDoc comments are included, but I haven't added any example to the readme. I also haven't added a benchmark of the FindMatching function itself, as the results would very much depend on the Filter function and should otherwise be very similar to Find.