### PR TITLE
Added DouglasPeuckerGeoIndexMap func

### DIFF
--- a/reducers/douglas_peucker_test.go
+++ b/reducers/douglas_peucker_test.go
@@ -45,7 +45,7 @@ func TestDouglasPeucker(t *testing.T) {
 	dp := NewDouglasPeucker(0.1)
 	p1 := p.Clone()
 	dp.GeoReduce(p)
-	if !p.Equals(p1){
+	if !p.Equals(p1) {
 		t.Errorf("dp GeoReduce should not modify original path")
 	}
 }
@@ -127,7 +127,6 @@ func TestDouglasPeuckerIndexMap(t *testing.T) {
 	}
 }
 
-
 func TestDouglasPeuckerGeoIndexMap(t *testing.T) {
 	p := geo.NewPath()
 
@@ -192,7 +191,7 @@ func TestDouglasPeuckerGeoIndexMap(t *testing.T) {
 	}
 
 	// 3 length, doesn't reduce
-	reduced, indexMap = DouglasPeuckerGeoIndexMap(p, threshold / 2)
+	reduced, indexMap = DouglasPeuckerGeoIndexMap(p, threshold/2)
 	if l := reduced.Length(); l != 3 {
 		t.Errorf("dpim reduce to incorrect number of points, expected 3, got %d", l)
 	}

--- a/reducers/douglas_peucker_test.go
+++ b/reducers/douglas_peucker_test.go
@@ -41,6 +41,13 @@ func TestDouglasPeucker(t *testing.T) {
 	if l := DouglasPeucker(p, 0.0).Length(); l != 2 {
 		t.Errorf("dp reduce should remove coliniar points")
 	}
+
+	dp := NewDouglasPeucker(0.1)
+	p1 := p.Clone()
+	dp.GeoReduce(p)
+	if !p.Equals(p1){
+		t.Errorf("dp GeoReduce should not modify original path")
+	}
 }
 
 func TestDouglasPeuckerIndexMap(t *testing.T) {
@@ -107,6 +114,85 @@ func TestDouglasPeuckerIndexMap(t *testing.T) {
 
 	// 3 length, doesn't reduce
 	reduced, indexMap = DouglasPeuckerIndexMap(p, 0.1)
+	if l := reduced.Length(); l != 3 {
+		t.Errorf("dpim reduce to incorrect number of points, expected 3, got %d", l)
+	}
+
+	if !reflect.DeepEqual(indexMap, []int{0, 1, 2}) {
+		t.Errorf("dpim should return []int{0, 1, 2} for index map, got %v", indexMap)
+	}
+
+	if reduced == p {
+		t.Error("should create new path and not modify original")
+	}
+}
+
+
+func TestDouglasPeuckerGeoIndexMap(t *testing.T) {
+	p := geo.NewPath()
+
+	// zero length
+	reduced, indexMap := DouglasPeuckerGeoIndexMap(p, 1)
+	if reduced.Length() != 0 {
+		t.Error("dpim should return same path if of length 0")
+	}
+
+	if len(indexMap) != 0 {
+		t.Error("dpim should have map of zero length for empty path input")
+	}
+
+	if reduced == p {
+		t.Error("should create new path and not modify original")
+	}
+
+	// 1 length
+	p.Push(geo.NewPointFromLatLng(0, 0))
+	reduced, indexMap = DouglasPeuckerGeoIndexMap(p, 1)
+	if !reduced.Equals(p) {
+		t.Error("dpim should return same path if of length 1")
+	}
+
+	if !reflect.DeepEqual(indexMap, []int{0}) {
+		t.Error("dpim should return []int{0} for index map when path is length 1")
+	}
+
+	if reduced == p {
+		t.Error("should create new path and not modify original")
+	}
+
+	// 2 length
+	p.Push(geo.NewPointFromLatLng(0.0001, 0.0002)) // 4th decimal place ~= 10m
+	threshold := 20.0
+	reduced, indexMap = DouglasPeuckerGeoIndexMap(p, threshold)
+	if !reduced.Equals(p) {
+		t.Error("dpim should return same path if of length 2")
+	}
+
+	if !reflect.DeepEqual(indexMap, []int{0, 1}) {
+		t.Error("dpim should return []int{0, 1} for index map when path is length 2")
+	}
+
+	if reduced == p {
+		t.Error("should create new path and not modify original")
+	}
+
+	// 3 length, does reduce
+	p.Push(geo.NewPointFromLatLng(0, 0.0003))
+	reduced, indexMap = DouglasPeuckerGeoIndexMap(p, threshold)
+	if l := reduced.Length(); l != 2 {
+		t.Errorf("dpim reduce to incorrect number of points, expected 2, got %d", l)
+	}
+
+	if !reflect.DeepEqual(indexMap, []int{0, 2}) {
+		t.Errorf("dpim should return []int{0, 2} for index map, got %v %v", indexMap, []int{0, 2})
+	}
+
+	if reduced == p {
+		t.Error("should create new path and not modify original")
+	}
+
+	// 3 length, doesn't reduce
+	reduced, indexMap = DouglasPeuckerGeoIndexMap(p, threshold / 2)
 	if l := reduced.Length(); l != 3 {
 		t.Errorf("dpim reduce to incorrect number of points, expected 3, got %d", l)
 	}


### PR DESCRIPTION
Like the DouglasPeuckerIndexMap func, but expects metres instead of
threshold value and performs Mercator transform before main DouglasPeucker
processing.

Also fixed a bug with DouglasPeucker GeoReduce() func that was mutating
the path parameter when performing the Mercator transform.

I've also included tests for these changes