### PR TITLE
Distance for k nearest

### DIFF
--- a/quadtree/examples_test.go
+++ b/quadtree/examples_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/paulmach/go.geo/quadtree"
 )
 
-func ExampleQuadtreeFind() {
+func ExampleQuadtree_Find() {
 	r := rand.New(rand.NewSource(42)) // to make things reproducible
 
 	qt := quadtree.New(geo.NewBound(0, 1, 0, 1))
@@ -25,7 +25,7 @@ func ExampleQuadtreeFind() {
 	// nearest: POINT(0.4930591659434973 0.5196585530161364)
 }
 
-func ExampleQuadtreeFindKNearest() {
+func ExampleQuadtree_FindKNearest() {
 	r := rand.New(rand.NewSource(42)) // to make things reproducible
 
 	qt := quadtree.New(geo.NewBound(0, 1, 0, 1))
@@ -46,7 +46,7 @@ func ExampleQuadtreeFindKNearest() {
 	// nearest: POINT(0.4930591659434973 0.5196585530161364)
 }
 
-func ExampleQuadtreeFindMatching() {
+func ExampleQuadtree_FindMatching() {
 	r := rand.New(rand.NewSource(42)) // to make things reproducible
 
 	type dataPoint struct {
@@ -74,7 +74,7 @@ func ExampleQuadtreeFindMatching() {
 	// nearest: {Pointer:POINT(0 0) visible:true}
 }
 
-func ExampleQuadtreeFindKNearestMatching() {
+func ExampleQuadtree_FindKNearestMatching() {
 	r := rand.New(rand.NewSource(42)) // to make things reproducible
 
 	type dataPoint struct {
@@ -104,7 +104,7 @@ func ExampleQuadtreeFindKNearestMatching() {
 	// nearest: [{Pointer:POINT(0 0) visible:true} {Pointer:POINT(0.6 0.6) visible:true}]
 }
 
-func ExampleQuadtreeInBound() {
+func ExampleQuadtree_InBound() {
 	r := rand.New(rand.NewSource(52)) // to make things reproducible
 
 	qt := quadtree.New(geo.NewBound(0, 1, 0, 1))

--- a/quadtree/quadtree_test.go
+++ b/quadtree/quadtree_test.go
@@ -183,6 +183,61 @@ func TestQuadtreeFindKNearest(t *testing.T) {
 	}
 }
 
+func TestQuadtreeFindKNearestWithDistanceLimit(t *testing.T) {
+	type dataPointer struct {
+		geo.Pointer
+		visible bool
+	}
+
+	q := NewFromPointers([]geo.Pointer{
+		dataPointer{geo.NewPoint(0, 0), false},
+		dataPointer{geo.NewPoint(1, 1), true},
+		dataPointer{geo.NewPoint(2, 2), false},
+		dataPointer{geo.NewPoint(3, 3), true},
+		dataPointer{geo.NewPoint(4, 4), false},
+		dataPointer{geo.NewPoint(5, 5), true},
+	})
+
+	// filters
+	filters := map[bool]Filter{
+		false: nil,
+		true:  func(p geo.Pointer) bool { return p.(dataPointer).visible },
+	}
+
+	// table test
+	type findTest struct {
+		Filtered bool
+		Distance float64
+		Point    *geo.Point
+		Expected []*geo.Point
+	}
+
+	tests := []findTest{
+		{Filtered: false, Distance: 2., Point: geo.NewPoint(0.1, 0.1), Expected: []*geo.Point{geo.NewPoint(0, 0), geo.NewPoint(1, 1)}},
+		{Filtered: true, Distance: 5., Point: geo.NewPoint(0.1, 0.1), Expected: []*geo.Point{geo.NewPoint(1, 1), geo.NewPoint(3, 3)}},
+	}
+
+	for i, test := range tests {
+		v := q.FindKNearestMatching(test.Point, 10, filters[test.Filtered], test.Distance)
+		if len(v) != len(test.Expected) {
+			t.Errorf("incorrect response length on %d", i)
+		}
+		for _, answer := range v {
+			found := false
+			for _, expected := range test.Expected {
+				if answer.Point().Equals(expected) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("incorrect point on %d, got %v", i, v)
+			}
+		}
+	}
+
+}
+
 func TestQuadtreeInBoundRandom(t *testing.T) {
 	r := rand.New(rand.NewSource(43))
 


### PR DESCRIPTION
In order to reduce search iterations, FindKNearestMatching allows defining max distance for "k" nearest items.