### PR TITLE
Allow flat arrays as input for paths

### DIFF
--- a/path.go
+++ b/path.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/paulmach/go.geojson"
+	"log"
 )
 
 // Path represents a set of points to be thought of as a polyline.
@@ -81,6 +82,21 @@ func NewPathFromXYData(data [][2]float64) *Path {
 
 	for i := range data {
 		p.PointSet = append(p.PointSet, Point{data[i][0], data[i][1]})
+	}
+
+	return p
+}
+
+// NewPathFromFlatXYData creates a path from a slice of float64 values
+// representing horizontal, vertical type data, for example lng/lat values from geojson.
+func NewPathFromFlatXYData(data []float64) *Path {
+	if (len(data) % 2 != 0) {
+		log.Fatal("Flat path requires an even number of coordinates")
+	}
+	p := NewPathPreallocate(0, len(data) / 2)
+
+	for i := 0; i < len(data) / 2; i++ {
+		p.PointSet = append(p.PointSet, Point{data[2 * i], data[2 * i + 1]})
 	}
 
 	return p

--- a/path_test.go
+++ b/path_test.go
@@ -79,6 +79,26 @@ func TestNewPathFromXYData(t *testing.T) {
 	}
 }
 
+func TestNewPathFromFlatXYData(t *testing.T) {
+	data := []float64{
+		1, 2,
+		3, 4,
+	}
+
+	p := NewPathFromFlatXYData(data)
+	if l := p.Length(); l != len(data) / 2 {
+		t.Errorf("path, should take full length of data, expected %d, got %d", len(data) / 2, l)
+	}
+
+	if point := p.GetAt(0); !point.Equals(&Point{1, 2}) {
+		t.Errorf("path, first point incorrect, got %v", point)
+	}
+
+	if point := p.GetAt(1); !point.Equals(&Point{3, 4}) {
+		t.Errorf("path, first point incorrect, got %v", point)
+	}
+}
+
 func TestNewPathFromYXData(t *testing.T) {
 	data := [][2]float64{
 		{1, 2},


### PR DESCRIPTION
When working only with paths it is useful to use a flat array.